### PR TITLE
Fix queue query

### DIFF
--- a/app/api/main.py
+++ b/app/api/main.py
@@ -449,7 +449,7 @@ async def get_jobs(mongodb_database=Depends(get_mongodb)) -> list[JobsGetRespons
         if job.get("name") == "automl_worker.run_autocluster":
             flower_job["clustering_algorithm"] = "AutoML"
             flower_job["dataset_name"] = ast.literal_eval(job.get("kwargs"))["dataset_name"]
-            flower_job["created_timestamp"] = "2025-07-18T18:07:18.273034+00:00"  # TODO: Replace dummy
+            flower_job["created_timestamp"] = ast.literal_eval(job.get("kwargs"))["created_timestamp"]
         else:
             args = ast.literal_eval(job.get("args"))
             flower_job["clustering_algorithm"] = args[-2]

--- a/app/api/main.py
+++ b/app/api/main.py
@@ -28,6 +28,8 @@ ALGORITHM_MAP = {
 }
 algorithms = [backend_name for backend_name in ALGORITHM_MAP]
 
+FLOWER_URL = os.getenv("FLOWER_URL")
+
 
 async def get_mongodb():
     MONGODB_DB = os.getenv("MONGODB_DB")
@@ -430,7 +432,7 @@ async def get_jobs(mongodb_database=Depends(get_mongodb)) -> list[JobsGetRespons
         job["status"] = "PERSISTED"
     mongodb_job_ids = [job["job_id"] for job in mongodb_jobs]
 
-    response = requests.get("http://caas-flower:5555/api/tasks")
+    response = requests.get(f"{FLOWER_URL}/api/tasks")
 
     if response.status_code != 200:
         print(f"Error fetching jobs from Flower: {response.text}")

--- a/app/api/main.py
+++ b/app/api/main.py
@@ -1,3 +1,4 @@
+import ast
 import io
 import os
 from datetime import datetime
@@ -7,6 +8,7 @@ from typing import Any
 import pandas as pd
 import plotly.express as px
 import pytz
+import requests
 from clustering import wrappers
 from clustering.preprocessing_params import PreProcessingParams
 from fastapi import Depends, FastAPI, File, HTTPException, Path, Query, UploadFile
@@ -410,8 +412,56 @@ class JobsGetResponse(BaseModel):
 @app.get("/jobs/")
 async def get_jobs(mongodb_database=Depends(get_mongodb)) -> list[JobsGetResponse]:
     """
-    Returns an overview of all known jobs including their status.
+    Get an overview of all clustering jobs and their current status.
+
+    Returns:
+        **list[JobsGetResponse]**: List of jobs with metadata and Celery status
+
+    Raises:
+        **HTTPException**: 500 for server errors
     """
+
+    results_collection = mongodb_database.get_collection("results")
+    mongodb_jobs = await results_collection.find(
+        {}, {"_id": 0, "job_id": 1, "dataset_name": 1, "created_timestamp": 1, "clustering_algorithm": 1}
+    ).to_list()
+
+    for job in mongodb_jobs:
+        job["status"] = "PERSISTED"
+    mongodb_job_ids = [job["job_id"] for job in mongodb_jobs]
+
+    response = requests.get("http://caas-flower:5555/api/tasks")
+
+    if response.status_code != 200:
+        print(f"Error fetching jobs from Flower: {response.text}")
+        raise HTTPException(status_code=500, detail="Error fetching jobs from Flower")
+
+    flower_jobs = list()
+    for job_id in response.json():
+        if job_id in mongodb_job_ids:
+            continue
+        job = response.json()[job_id]
+        flower_job = dict()
+        flower_job["job_id"] = job_id
+        flower_job["status"] = job.get("state")
+        if job.get("name") == "automl_worker.run_autocluster":
+            flower_job["clustering_algorithm"] = "AutoML"
+            flower_job["dataset_name"] = ast.literal_eval(job.get("kwargs"))["dataset_name"]
+            flower_job["created_timestamp"] = "2025-07-18T18:07:18.273034+00:00"  # TODO: Replace dummy
+        else:
+            args = ast.literal_eval(job.get("args"))
+            flower_job["clustering_algorithm"] = args[-2]
+            flower_job["dataset_name"] = args[0]
+            flower_job["created_timestamp"] = args[-3]
+        flower_jobs.append(flower_job)
+
+    result = sorted(
+        flower_jobs + mongodb_jobs,
+        key=lambda job: job.get("created_timestamp"),
+        reverse=True,
+    )
+    return result
+
     try:
         results_collection = mongodb_database.get_collection("results")
         jobs = await results_collection.find({}, {"_id": 0}).to_list(length=1000)
@@ -689,29 +739,6 @@ async def start_automl(req: AutoMlClusterRequest) -> AutoMlClusterResponse:
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error starting AutoML-Job: {str(e)}")
-
-
-@app.get("/debug/job/{job_id}")
-async def debug_job(job_id: str, mongodb_database=Depends(get_mongodb)):
-    """
-    Debug endpoint to check job status and results
-    """
-    try:
-        # Check Celery task
-        task = celery.AsyncResult(job_id)
-        task_info = {
-            "job_id": task.id,
-            "status": task.status,
-            "result": task.result if task.ready() else None,
-        }
-
-        # Check MongoDB
-        results_collection = mongodb_database.get_collection("results")
-        stored_result = await results_collection.find_one({"job_id": job_id})
-
-        return {"task_info": task_info, "stored_result": stored_result is not None}
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Debug error: {str(e)}") from e
 
 
 @app.get("/parameters/{algorithm_name}")

--- a/app/clustering/base_clustering.py
+++ b/app/clustering/base_clustering.py
@@ -137,7 +137,7 @@ class BaseClustering(ABC):
                 "created_timestamp": created_timestamp,
                 "started_timestamp": started_timestamp,
                 "finished_timestamp": datetime.now(TIMEZONE).isoformat(),
-                "clustering_algorithm": self.frontend_name,
+                "clustering_algorithm": self.backend_name,
                 "clustering_params": self.clustering_params,
                 "preprocessing_params": self.preprocessing_params,
                 "labels": labels,

--- a/app/clustering_worker-requirements.txt
+++ b/app/clustering_worker-requirements.txt
@@ -3,3 +3,4 @@ pandas
 requests
 celery[redis,rabbitmq]
 pydantic
+flower

--- a/app/frontend/app.py
+++ b/app/frontend/app.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import time
 from typing import Literal, get_args
 
 import pandas as pd
@@ -47,6 +46,37 @@ def get_available_clustering_algorithms():
     Dynamically loads all clustering algorithms from the clustering directory.
     Excludes abstract base class.
     """
+
+    algorithms = {
+        getattr(wrappers, algo).frontend_name: getattr(wrappers, algo)
+        for algo in dir(wrappers)
+        if algo.endswith("Wrapper")
+    }
+
+    return algorithms
+
+
+def get_backend_frontend_mapping():
+    """
+    Dynamically loads the frontend name for each backend name from the clustering directory.
+    Excludes abstract base class.
+    """
+
+    mapping = {
+        getattr(wrappers, algo).backend_name: getattr(wrappers, algo).frontend_name
+        for algo in dir(wrappers)
+        if algo.endswith("Wrapper")
+    }
+
+    return mapping
+
+    algorithms = {
+        getattr(wrappers, algo).backend_name: getattr(wrappers, algo)
+        for algo in dir(wrappers)
+        if algo.endswith("Wrapper")
+    }
+
+    return algorithms
 
     algorithms = {
         getattr(wrappers, algo).frontend_name: getattr(wrappers, algo)
@@ -342,34 +372,6 @@ if st.session_state["dataset_name"]:
                 st.session_state["job_id"] = job_id
                 st.success(f"Clustering gestartet! Job-ID: {job_id}")
 
-                # Fortschrittsanzeige
-                status_placeholder = st.empty()
-                progress = 0
-                max_wait = cutoff_time  # max 2 Minuten warten
-                poll_interval = 2  # alle 2 Sekunden abfragen
-
-                for _ in range(max_wait // poll_interval):
-                    debug_resp = requests.get(f"{FASTAPI_URL}/debug/job/{job_id}")
-                    if debug_resp.status_code == 200:
-                        debug_data = debug_resp.json()
-                        celery_status = debug_data["task_info"]["status"]
-                        if celery_status == "PENDING":
-                            status_placeholder.info("Job ist in der Warteschlange (PENDING)...")
-                        elif celery_status == "STARTED":
-                            status_placeholder.info("Clustering läuft (STARTED)...")
-                        elif celery_status == "SUCCESS":
-                            status_placeholder.success("Clustering abgeschlossen!")
-                            break
-                        elif celery_status == "FAILURE":
-                            status_placeholder.error("Clustering fehlgeschlagen!")
-                            break
-                        else:
-                            status_placeholder.warning(f"Status: {celery_status}")
-                    else:
-                        status_placeholder.warning("Status konnte nicht abgefragt werden.")
-                    time.sleep(poll_interval)
-                else:
-                    status_placeholder.warning("Timeout: Clustering hat zu lange gedauert.")
             else:
                 st.error("Fehler beim Starten des Clusterings")
         except Exception as e:
@@ -381,7 +383,9 @@ if st.session_state["dataset_name"]:
 st.subheader("Ergebnisse anzeigen")
 
 # Auswahlmodus für die Job-Auswahl
-job_select_mode = st.radio("Job auswählen", ["Manuelle Eingabe", "Aktuellen Job anzeigen", "Job-Historie"])
+job_select_mode = st.radio(
+    label="Job auswählen", options=["Manuelle Eingabe", "Aktuellen Job anzeigen", "Job-Historie"], index=0
+)
 
 input_job_id = ""
 if job_select_mode == "Manuelle Eingabe":
@@ -400,14 +404,6 @@ elif job_select_mode == "Job-Historie":
             resp = requests.get(f"{FASTAPI_URL}/jobs/")
             if resp.status_code == 200:
                 jobs = resp.json()
-                # Status für jeden Job live abfragen
-                for job in jobs:
-                    job_id = job.get("job_id")
-                    if job_id:
-                        debug_resp = requests.get(f"{FASTAPI_URL}/debug/job/{job_id}")
-                        if debug_resp.status_code == 200:
-                            celery_status = debug_resp.json()["task_info"]["status"]
-                            job["status"] = celery_status
                 return jobs
             else:
                 return []
@@ -419,9 +415,10 @@ elif job_select_mode == "Job-Historie":
     job_id_to_label = {}
     if job_list:
         # Sortiere die Liste so, dass die neuesten Jobs zuerst stehen
-        job_list = sorted(job_list, key=lambda job: job.get("created_timestamp", ""), reverse=True)
+        job_list = sorted(job_list, key=lambda job: job.get("created_timestamp"), reverse=True)
         for job in job_list:
-            label = f"{job['job_id']} | {job['dataset_name']} | {job['clustering_algorithm']} | {job['status']}"
+            algorithm_name = get_backend_frontend_mapping().get(job.get("clustering_algorithm"))
+            label = f"{job['job_id']} | {job['dataset_name']} | {algorithm_name} | {job['status']}"
             job_options.append(label)
             job_id_to_label[label] = job["job_id"]
         selected_label = st.selectbox(
@@ -432,59 +429,70 @@ elif job_select_mode == "Job-Historie":
     else:
         st.info("Keine Jobs vorhanden.")
 
-presentation = st.selectbox("Wie sollen Ergebnisse präsentiert werden?", ["Graph", "Tabelle"])
+presentation = ""
+if job_select_mode != "Job-Historie" or selected_label.endswith(" | PERSISTED"):
+    presentation = st.selectbox("Wie sollen Ergebnisse präsentiert werden?", ["Graph", "Tabelle"])
 
-if presentation == "Graph" and input_job_id:
-    url = f"{FASTAPI_URL}/result/{input_job_id}/raw"
-    response = requests.get(url, params={"field": "columns"})
+    if presentation == "Graph" and input_job_id:
+        url = f"{FASTAPI_URL}/result/{input_job_id}/raw"
+        response = requests.get(url, params={"field": "columns"})
 
-    if response.status_code == 404:
-        st.error("Keine Ergebnisse für diese Job-ID gefunden.")
-        st.stop()
-    else:
-        available_result_columns = response.json()
-        available_result_columns = [col.get("name") for col in available_result_columns]
-        selected_result_columns = st.multiselect(
-            "Welche Spalten sollen für den Graphen verwendet werden?",
-            options=available_result_columns,
-            default=available_result_columns[:2],
-            max_selections=2,
-        )
-
-if st.button("Ergebnis anzeigen") and input_job_id:
-    mapping = {"Tabelle": "table", "Graph": "graph"}
-    pres = mapping[presentation]
-    url = f"{FASTAPI_URL}/result/{input_job_id}/{pres}"
-
-    if len(selected_result_columns) != 2 and pres == "graph":
-        st.error("Für den Graphen müssen genau zwei Spalten ausgewählt werden.")
-        st.stop()
-    try:
-        params = (
-            None
-            if pres == "table"
-            else {
-                "x_column": selected_result_columns[0],
-                "y_column": selected_result_columns[1],
-            }
-        )
-        resp = requests.get(url, params=params)
-        if resp.status_code == 200:
-            data = resp.json()
-            # Präsentation auf voller Breite
-            if pres == "table":
-                st.dataframe(pd.DataFrame(data), use_container_width=True)
-            elif pres == "graph":
-                fig = go.Figure(data)
-                if not fig.data:
-                    st.warning("Keine Daten für Plot vorhanden.")
-                else:
-                    st.plotly_chart(fig, use_container_width=True)
+        if response.status_code == 404:
+            st.warning(
+                ""
+                "Entweder gibt es keine Jobs zu dieser ID "
+                "oder die Ergebnisse sind noch nicht verfügbar. "
+                "Bitte prüfen Sie, ob die ID gültig ist oder warten Sie, "
+                "bis der Job abgeschlossen ist."
+            )
+            st.stop()
         else:
-            try:
-                msg = resp.json().get("detail", resp.text)
-            except Exception:
-                msg = resp.text
-            st.error(f"Fehler: {msg}")
-    except Exception as e:
-        st.error(f"Fehler beim Abrufen der Ergebnisse: {e}")
+            available_result_columns = response.json()
+            available_result_columns = [col.get("name") for col in available_result_columns]
+            selected_result_columns = st.multiselect(
+                "Welche Spalten sollen für den Graphen verwendet werden?",
+                options=available_result_columns,
+                default=available_result_columns[:2],
+                max_selections=2,
+            )
+
+    if st.button("Ergebnis anzeigen") and input_job_id:
+        mapping = {"Tabelle": "table", "Graph": "graph"}
+        pres = mapping[presentation]
+        url = f"{FASTAPI_URL}/result/{input_job_id}/{pres}"
+
+        if len(selected_result_columns) != 2 and pres == "graph":
+            st.error("Für den Graphen müssen genau zwei Spalten ausgewählt werden.")
+            st.stop()
+        try:
+            params = (
+                None
+                if pres == "table"
+                else {
+                    "x_column": selected_result_columns[0],
+                    "y_column": selected_result_columns[1],
+                }
+            )
+            resp = requests.get(url, params=params)
+            if resp.status_code == 200:
+                data = resp.json()
+                # Präsentation auf voller Breite
+                if pres == "table":
+                    st.dataframe(pd.DataFrame(data), use_container_width=True)
+                elif pres == "graph":
+                    fig = go.Figure(data)
+                    if not fig.data:
+                        st.warning("Keine Daten für Plot vorhanden.")
+                    else:
+                        st.plotly_chart(fig, use_container_width=True)
+            else:
+                try:
+                    msg = resp.json().get("detail", resp.text)
+                except Exception:
+                    msg = resp.text
+                st.error(f"Fehler: {msg}")
+        except Exception as e:
+            st.error(f"Fehler beim Abrufen der Ergebnisse: {e}")
+else:
+    st.warning("Die Ergebnisse sind noch nicht verfügbar. Bitte warten Sie, bis der Job abgeschlossen ist.")
+    st.stop()

--- a/app/workers/tasks.py
+++ b/app/workers/tasks.py
@@ -23,34 +23,29 @@ def run_clustering_job(
     preprocessing_params,
     **clustering_params,
 ):
-    try:
-        print(f"Running clustering job for {dataset_name} with algorithm {clustering_algorithm}")
-        started_timestamp = datetime.now(TIMEZONE).isoformat()
+    print(f"Running clustering job for {dataset_name} with algorithm {clustering_algorithm}")
+    started_timestamp = datetime.now(TIMEZONE).isoformat()
 
-        job_id = self.request.id
+    job_id = self.request.id
 
-        algorithm_name = clustering_algorithm.lower()
-        if algorithm_name not in ALGORITHM_MAP:
-            raise ValueError(f"Unsupported algorithm: {algorithm_name}")
+    algorithm_name = clustering_algorithm.lower()
+    if algorithm_name not in ALGORITHM_MAP:
+        raise ValueError(f"Unsupported algorithm: {algorithm_name}")
 
-        clustering_class = ALGORITHM_MAP[algorithm_name]
-        clustering = clustering_class(dataset_name, columns, preprocessing_params, **clustering_params)
+    clustering_class = ALGORITHM_MAP[algorithm_name]
+    clustering = clustering_class(dataset_name, columns, preprocessing_params, **clustering_params)
 
-        # Clustering parameters validation
-        # Temporarily removed because it throws false positive errors when n_clusters > 4
-        # clustering.validate_params_sklearn()
+    # Clustering parameters validation
+    # Temporarily removed because it throws false positive errors when n_clusters > 4
+    # clustering.validate_params_sklearn()
 
-        data = clustering.load_data()
+    data = clustering.load_data()
 
-        # Encoding nominal or ordinal columns
-        df = clustering.encode_data(data)
-        data = df.to_numpy()
+    # Encoding nominal or ordinal columns
+    df = clustering.encode_data(data)
+    data = df.to_numpy()
 
-        data = clustering.prepare_data(data, preprocess)
-        result = clustering.run(data)
+    data = clustering.prepare_data(data, preprocess)
+    result = clustering.run(data)
 
-        clustering.save_results(result, job_id, created_timestamp, started_timestamp)
-
-    except Exception as e:
-        print(f"Error in clustering job: {str(e)}")
-        return {"status": "error", "message": str(e)}
+    clustering.save_results(result, job_id, created_timestamp, started_timestamp)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,10 +43,10 @@ services:
     volumes:
       - rabbitmq-lib:/var/lib/rabbitmq
       - rabbitmq-log:/var/log/rabbitmq
-      # - type: bind
-      #   source: ./message_broker/.erlang.cookie
-      #   target: /var/lib/rabbitmq/.erlang.cookie
-      #   read_only: true
+    # - type: bind
+    #   source: ./message_broker/.erlang.cookie
+    #   target: /var/lib/rabbitmq/.erlang.cookie
+    #   read_only: true
     user: rabbitmq
     healthcheck:
       test: rabbitmq-diagnostics ping
@@ -85,6 +85,23 @@ services:
     container_name: caas-redis
     ports:
       - '6379:6379'
+
+  flower:
+    container_name: caas-flower
+    build:
+      context: ./app
+      dockerfile: clustering_worker.Dockerfile
+    command: celery -A workers.tasks flower --port=5555
+    env_file:
+      - ./message_broker/.env
+      - ./redis/.env
+      - ./app/api/.env
+    environment:
+      - FLOWER_UNAUTHENTICATED_API=true
+    ports:
+      - "5555:5555"
+    depends_on:
+      - rabbitmq
 
   automl-worker:
     container_name: caas-automl_worker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - ./mongodb/.env
     environment:
       - DEBUG=1 # For hot reload
+      - FLOWER_URL=http://caas-flower:5555
 
   streamlit:
     container_name: caas-streamlit

--- a/integration_tests/test_ci.py
+++ b/integration_tests/test_ci.py
@@ -170,7 +170,7 @@ def test_post_jobs_numeric_and_text():
         assert response.status_code == 200
         result = response.json()
         assert isinstance(result, list)
-        assert len(result) > 0  # Ensure there are job statuses returned
+        assert len(result) > 0
 
 def test_automl_iris():
     available_cluster_algorithms = [
@@ -218,9 +218,17 @@ def test_automl_iris():
 
     response = requests.post(f"{FASTAPI_URL}/automl/job", json=body)
     assert response.status_code == 200
+    job_response = response.json()
+    assert "job_id" in job_response
+    assert job_response["job_id"] is not None
 
-    # TODO: Check if the result is saved to mongodb
-    # For that the automl worker needs to be reworked to handle the new column format
+    sleep(20)  # Wait for the job to be processed
+
+    response = requests.get(f"{FASTAPI_URL}/result/{job_response['job_id']}/raw")
+    assert response.status_code == 200
+    result = response.json()
+    assert isinstance(result, list)
+    assert len(result) > 0 
 
 def test_delete_iris():
     response = requests.delete(f"{FASTAPI_URL}/dataset/iris.csv")

--- a/integration_tests/test_ci.py
+++ b/integration_tests/test_ci.py
@@ -222,7 +222,7 @@ def test_automl_iris():
     assert "job_id" in job_response
     assert job_response["job_id"] is not None
 
-    sleep(20)  # Wait for the job to be processed
+    sleep(60)  # Wait for the job to be processed
 
     response = requests.get(f"{FASTAPI_URL}/result/{job_response['job_id']}/raw")
     assert response.status_code == 200


### PR DESCRIPTION
Ich habe die Art, wie der Job-Status abgefragt wird, recht grundlegend überarbeitet.

Dafür musste ich einen neuen Service "Flower" implementieren, der das gleiche Image/Dockerfile verwendet, wie der Clustering-Worker.

Flower ist ein Bestandteil von Celery, der die Überwachung von celery tasks erlaubt.

Der Vorteil ist, dass die jetzt auch die Jobs angezeigt werden, deren Ergebnisse noch nicht in mongodb liegen.

Wenn ein Job seine Ergebnisse bereits zu mongodb geschrieben hat, erhalten sie bei Abfrage durch FastAPI den Status "PERSISTED".